### PR TITLE
Fix crash when URL can not be resolved

### DIFF
--- a/zoom/zoom_api.py
+++ b/zoom/zoom_api.py
@@ -70,7 +70,7 @@ class ZoomAPI:
       # Failed to make a connection so let's just return a 404, as there is no file
       # but print an additional warning in case it was a configuration error
       print("Exception during recording request: ", e)
-      raise ZoomAPIException(404, 'File Not Found', zoom_request.request, 'Could not connect')
+      raise ZoomAPIException(404, 'File Not Found', None, 'Could not connect')
     if zoom_request.status_code == 401:
       # Handle unauthenticated requests.
       raise ZoomAPIException(401, 'Unauthorized', zoom_request.request, 'Not authenticated.')
@@ -137,7 +137,7 @@ class ZoomAPI:
     except ZoomAPIException as ze:
       print(ze)
 
-      if ze.http_method == 'DELETE':
+      if ze.http_method and ze.http_method == 'DELETE':
         # Allow other systems to proceed if delete fails.
         return (True, True)
       return (False, False)

--- a/zoom/zoom_api_exception.py
+++ b/zoom/zoom_api_exception.py
@@ -32,4 +32,4 @@ class ZoomAPIException(Exception):
   def http_method(self):
     """Returns request method.
     """
-    return self.method.method
+    return self.method.method if self.method else None


### PR DESCRIPTION
This problem happens rarely in production, but testing it with manually modified (invalid) URLs shows that this fix prevents the crash and lets the program continue as before and handles an unresolvable URL as a (hopefully) temporary HTTP 404 error with a bit more debug information in case the user used a wrongly configured URL. 

This fixes #4  