### PR TITLE
Download fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ zoom:
   key: "zoom_api_key"
   secret: "zoom_api_secret"
   username: "email@example.com"
-  password: "password for email@example.com" # required to download files from Zoom.
   delete: true
   meetings: 
     - {id: "meeting_id" , name: "Meeting Name"}
@@ -43,11 +42,10 @@ To get the proper API key and secret, you will need to use the following
 "Getting Started Guide" on Zoom's developer site. Link [here](https://developer.zoom.us/docs/windows/introduction-and-pre-requisite/).
 Paste the API key and secret into `config.yaml` under the `zoom` section.
 
-It is (currently) not possible to download the recordings via the API key. 
-As such you need to create a new Zoom user within your organizations Zoom account. 
-This can be a non-pro user. It is important that this user logs in via a username 
-and password. The username and password for this account should be added 
-to the `username` and `password` entries under the `zoom` section.
+It is (currently) not possible to download the recordings via the API key only. 
+As such you need to specify a user that is part of your organizations Zoom account. 
+This can be a non-pro user. The e-mail of the user should be added
+to the `username` entry under the `zoom` section.
 
 ### Google Drive
 To upload files to Google Drive you have to login to your developer console, create a new project,

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -78,7 +78,6 @@ class TestZoomConfig(TestSettingsBase):
   def test_getattr(self):
     self.assertEqual(self.zoom.key, 'some_key')
     self.assertEqual(self.zoom.username, 'some@email.com')
-    self.assertEqual(self.zoom.password, 's0mer4ndomv4lue!')
     self.assertTrue(self.zoom.delete)
     self.assertEqual(self.zoom.meetings,
                      [{'id': 'first_id', 'name': 'meeting1'},
@@ -157,7 +156,6 @@ class TestConfigInterface(unittest.TestCase):
       '  key: "zoom_api_key"\n'
       '  secret: "zoom_api_secret"\n'
       '  username: "email@example.com"\n'
-      '  password: "password for email@example.com"\n'
       '  delete: true\n'
       '  meetings:\n'
       '    - {id: "meeting_id" , name: "Meeting Name"}\n'
@@ -211,7 +209,6 @@ class TestConfigInterface(unittest.TestCase):
       key: "zoom_api_key"
       secret: "zoom_api_secret"
       username: "email@example.com"
-      password: "password for email@example.com"
       delete: true
       meetings:
         - {id: "meeting_id" , name: "Meeting Name"}

--- a/tests/unittest_settings.py
+++ b/tests/unittest_settings.py
@@ -22,7 +22,6 @@ class TestSettingsBase(unittest.TestCase):
     self.zoom_config = {'key': 'some_key',
                         'secret': 'some_secret',
                         'username': 'some@email.com',
-                        'password': 's0mer4ndomv4lue!',
                         'delete': True,
                         'meetings': [
                           {'id': 'first_id', 'name': 'meeting1'},

--- a/zoom/zoom_api.py
+++ b/zoom/zoom_api.py
@@ -106,6 +106,8 @@ class ZoomAPI:
         # TODO(jbedorf): For now just delete the chat messages and continue processing other files.
         if req['file_type'] == 'CHAT':
           self.delete_recording(meeting_id, req['id'], auth)
+        elif req['file_type'] == 'TRANSCRIPT':
+          self.delete_recording(meeting_id, req['id'], auth)
         elif req['file_type'] == 'MP4':
           date = datetime.datetime.strptime(req['recording_start'], '%Y-%m-%dT%H:%M:%SZ')
           return {'date': date, 'id': req['id'], 'url': req['download_url']}
@@ -144,7 +146,7 @@ class ZoomAPI:
       raise ZoomAPIException(status_code, zoom_request.reason, zoom_request.request, '')
 
     # Use the zak token in order to download the file
-    zoom_request = requests.get(url+"?zak=" + zoom_request.json()['token'], stream=True)
+    zoom_request = requests.get(url + "?zak=" + zoom_request.json()['token'], stream=True)
     filename = url.split('/')[-1]
     outfile = os.path.join(str(self.sys_config.target_folder), filename + '.mp4')
     with open(outfile, 'wb') as source:

--- a/zoom/zoom_api.py
+++ b/zoom/zoom_api.py
@@ -33,6 +33,7 @@ S = TypeVar("S", bound=APIConfigBase)
 
 class ZoomURLS(Enum):
   recordings = 'https://api.zoom.us/v2/meetings/{id}/recordings'
+  zak_token = 'https://api.zoom.us/v2/users/{user}/token?type=zak'
   delete_recordings = 'https://api.zoom.us/v2/meetings/{id}/recordings/{rid}'
   signin = 'https://api.zoom.us/signin'
 
@@ -100,6 +101,7 @@ class ZoomAPI:
 
     status_code = zoom_request.status_code
     if 200 <= status_code <= 299:
+      log.log(logging.DEBUG, zoom_request.json())
       for req in zoom_request.json()['recording_files']:
         # TODO(jbedorf): For now just delete the chat messages and continue processing other files.
         if req['file_type'] == 'CHAT':
@@ -116,26 +118,38 @@ class ZoomAPI:
     else:
       raise ZoomAPIException(status_code, zoom_request.reason, zoom_request.request, '')
 
-  def download_recording(self, url: str) -> str:
+  def download_recording(self, url: str, auth: bytes) -> str:
     """Downloads video file from Zoom to local folder.
 
     :param url: Download URL for meeting recording.
+    :param auth: Encoded JWT authorization token
     :return: Path to the recording
     """
-    session = requests.Session()
-    session.headers.update({'content-type': 'application/x-www-form-urlencoded'})
 
-    session.post(
-        ZoomURLS.signin.value,
-        data={'email': str(self.zoom_config.username),
-              'password': str(self.zoom_config.password)})
+    # Generate a zak token, required for direct download
+    zoom_url = str(ZoomURLS.zak_token.value).format(user=self.zoom_config.username)
+    try:
+      zoom_request = requests.get(zoom_url, params={'access_token': auth})
+    except requests.exceptions.RequestException as e:
+      log.log(logging.ERROR, e)
+      raise ZoomAPIException(404, 'File Not Found', None, 'Could not connect')
 
+    status_code = zoom_request.status_code
+    if 200 <= status_code <= 299:
+      log.log(logging.DEBUG, zoom_request.json())
+    elif 300 <= status_code <= 599:
+      raise ZoomAPIException(status_code, zoom_request.reason, zoom_request.request,
+                             self.message.get(status_code, ''))
+    else:
+      raise ZoomAPIException(status_code, zoom_request.reason, zoom_request.request, '')
+
+    # Use the zak token in order to download the file
+    zoom_request = requests.get(url+"?zak=" + zoom_request.json()['token'], stream=True)
     filename = url.split('/')[-1]
-    zoom_request = session.get(url, stream=True)
-
     outfile = os.path.join(str(self.sys_config.target_folder), filename + '.mp4')
     with open(outfile, 'wb') as source:
       shutil.copyfileobj(zoom_request.raw, source)  # Copy raw file data to local file.
+
     return outfile
 
   def pull_file_from_zoom(self, meeting_id: str, rm: bool = True) -> Dict[str, Any]:
@@ -155,7 +169,7 @@ class ZoomAPI:
 
       # Get URL and download the file.
       res = self.get_recording_url(meeting_id, zoom_token)
-      filename = self.download_recording(res['url'])
+      filename = self.download_recording(res['url'], zoom_token)
 
       if rm:
         self.delete_recording(meeting_id, res['id'], zoom_token)


### PR DESCRIPTION
This PR removes the need to login to Zoom to download files. It is replaced by generating a different kind of access token that is used for the file download operation. 

- Updated the unit tests to be compatible with this.
- Removed all uses off the `password` variable.
 
Note I reformatted the unit test file with `yapf` which causes the large amount of line changes. 