### PR TITLE
Fixes for Zoom's authentication change

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(path.join(current_directory, 'README.md'), encoding='utf-8') as f:
 
 setup(
   name='zoom-drive-connector',
-  version='1.4',
+  version='1.6',
   packages=find_packages(exclude=['tests']),
   url='https://github.com/minds-ai/zoom-drive-connector',
   license='Apache 2.0',

--- a/zoom_drive_connector/zoom/zoom_api.py
+++ b/zoom_drive_connector/zoom/zoom_api.py
@@ -74,9 +74,12 @@ class ZoomAPI:
     :param auth: JWT token.
     """
     zoom_url = str(ZoomURLS.delete_recordings.value).format(id=meeting_id, rid=recording_id)
-    res = requests.delete(
-        zoom_url, params={'access_token': auth,
-                          'action': 'trash'})  # trash, not delete
+    headers = {
+      'authorization': 'Bearer ' + auth.decode("utf-8"),
+      'content-type': 'application/json'
+    }
+    # trash, not delete
+    res = requests.delete(zoom_url, headers=headers, params={'action': 'trash'})
     status_code = res.status_code
     if 400 <= status_code <= 499:
       raise ZoomAPIException(status_code, res.reason, res.request, self.message.get(
@@ -93,7 +96,11 @@ class ZoomAPI:
     zoom_url = str(ZoomURLS.recordings.value).format(id=meeting_id)
 
     try:
-      zoom_request = requests.get(zoom_url, params={'access_token': auth})
+      headers = {
+        'authorization': 'Bearer ' + auth.decode("utf-8"),
+        'content-type': 'application/json'
+      }
+      zoom_request = requests.get(zoom_url, headers=headers)
     except requests.exceptions.RequestException as e:
       # Failed to make a connection so let's just return a 404, as there is no file
       # but print an additional warning in case it was a configuration error
@@ -133,8 +140,11 @@ class ZoomAPI:
     :param auth: Encoded JWT authorization token
     :return: Path to the recording
     """
-    zoom_request = requests.get(url, stream=True, params={'access_token': auth})
-
+    headers = {
+      'authorization': 'Bearer ' + auth.decode("utf-8"),
+      'content-type': 'application/json'
+    }
+    zoom_request = requests.get(url, stream=True, headers=headers)
 
     filename = url.split('/')[-1]
     outfile = os.path.join(str(self.sys_config.target_folder), filename + '.mp4')


### PR DESCRIPTION
Authentication tokens are no longer allowed to be passed via the parameters. 